### PR TITLE
Add --copy-link / -c option, make some general code improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+Package.swift
 .DS_Store

--- a/main.swift
+++ b/main.swift
@@ -18,9 +18,9 @@ func isEntangled() -> Bool {
     defer { IOObjectRelease(service) }
     
     if (service == 0) { return false }
-    guard let engtangleNonceData = IORegistryEntrySearchCFProperty(
+    guard IORegistryEntrySearchCFProperty(
         service, kIODeviceTreePlane, "entangle-nonce" as NSString, kCFAllocatorDefault, UInt32(kIORegistryIterateRecursively)
-    ) else {
+    ) != nil else {
         return false
     }
     
@@ -30,20 +30,20 @@ func isEntangled() -> Bool {
 func request(body: [String : String], _ completion: @escaping ((_ success: Bool, _ data: Data?) -> Void)) {
     var request = URLRequest(url: URL(string: "https://tsssaver.1conan.com/v2/api/save.php")!)
     request.httpMethod = "POST"
-
+    
     do {
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: .prettyPrinted)
     } catch let error {
         print(error.localizedDescription)
         exit(1)
     }
-
+    
     request.addValue("text/plain;charset=UTF-8", forHTTPHeaderField: "Content-Type")
     request.addValue("*/*", forHTTPHeaderField: "Accept")
     
     let config = URLSessionConfiguration.default
     config.waitsForConnectivity = true
-
+    
     URLSession(configuration: config).dataTask(with: request) { data, _, _ -> Void in
         if let data = data {
             return completion(true, data)
@@ -64,11 +64,11 @@ dimentio_term()
 free(nonce_d)
 
 guard let ecid = MGCopyAnswer("UniqueChipID" as CFString),
-let device = MGCopyAnswer("ProductType" as CFString),
-let board = MGCopyAnswer("HWModelStr" as CFString) else {
-    print("Can't read device values")
-    exit(1)
-}
+      let device = MGCopyAnswer("ProductType" as CFString),
+      let board = MGCopyAnswer("HWModelStr" as CFString) else {
+          print("Can't read device values")
+          exit(1)
+      }
 
 let ecidInt = ecid.takeRetainedValue() as! Int // Decimal ECID
 let deviceString = device.takeRetainedValue() as! String // iPad8,11
@@ -85,10 +85,10 @@ if !nonceStr.isEmpty && !generatorStr.isEmpty {
 
 request(body: parameters) { success, data in
     guard success,
-      let data = data else {
-        print("Request to TSSSaver was unsuccessful")
-        exit(1)
-    }
+          let data = data else {
+              print("Request to TSSSaver was unsuccessful")
+              exit(1)
+          }
     do {
         if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
             guard let link = json["url"] as? String else {

--- a/main.swift
+++ b/main.swift
@@ -1,6 +1,6 @@
 // Thanks to 1conan's TSSSaver and 0x7ff's libdimentio
 
-import Foundation
+import UIKit
 
 @_silgen_name("MGCopyAnswer")
 func MGCopyAnswer(_: CFString) -> Optional<Unmanaged<CFPropertyList>>
@@ -96,6 +96,10 @@ request(body: parameters) { success, data in
                 exit(1)
             }
             print("Link to blobs: \(link)")
+            if CommandLine.arguments.contains("--copy") || CommandLine.arguments.contains("-c") {
+                UIPasteboard.general.string = link
+                print("Copied link to clipboard.")
+            }
             exit(0)
         }
     } catch {

--- a/main.swift
+++ b/main.swift
@@ -6,11 +6,10 @@ import UIKit
 func MGCopyAnswer(_: CFString) -> Optional<Unmanaged<CFPropertyList>>
 
 var nonce_d = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(CC_SHA384_DIGEST_LENGTH))
-var ret: CInt = EXIT_FAILURE
 var nonce_d_sz: size_t = 0
 var generator: UInt64 = 0
-var generatorStr : String = ""
-var nonceStr : String = ""
+var generatorStr: String?
+var nonceStr: String?
 
 func isEntangled() -> Bool {
     let matching = IOServiceMatching("IOPlatformExpertDevice")
@@ -56,10 +55,14 @@ if (isEntangled() && (dimentio_preinit(&generator, false, nonce_d, &nonce_d_sz) 
     generatorStr = "0x" + String(generator, radix:16).uppercased()
     let buffer = UnsafeBufferPointer(start: nonce_d, count: nonce_d_sz)
     nonceStr = buffer.map { String(format: "%02X", $0) }.joined()
+}
+
+if let generatorStr = generatorStr, let nonceStr = nonceStr {
     print("libdimentio success\nProceeding with current generator (\(generatorStr)) and nonce (\(nonceStr))")
 } else {
     print("Not using libdimentio (A11 and below)\nProceeding without current generator and nonce")
 }
+
 dimentio_term()
 free(nonce_d)
 
@@ -78,7 +81,7 @@ var parameters = ["ecid": "\(ecidInt)",
                   "deviceIdentifier": deviceString,
                   "boardConfig": boardString]
 
-if !nonceStr.isEmpty && !generatorStr.isEmpty {
+if let nonceStr = nonceStr, let generatorStr = generatorStr {
     parameters["apnonce"] = nonceStr
     parameters["generator"] = generatorStr
 }

--- a/main.swift
+++ b/main.swift
@@ -15,15 +15,15 @@ var nonceStr : String = ""
 func isEntangled() -> Bool {
     let matching = IOServiceMatching("IOPlatformExpertDevice")
     let service = IOServiceGetMatchingService(kIOMasterPortDefault, matching)
+    defer { IOObjectRelease(service) }
+    
     if (service == 0) { return false }
-    let engtangleNonceData = IORegistryEntrySearchCFProperty(service, kIODeviceTreePlane, "entangle-nonce" as NSString, kCFAllocatorDefault, UInt32(kIORegistryIterateRecursively))
-
-    if (engtangleNonceData == nil) {
-        IOObjectRelease(service)
+    guard let engtangleNonceData = IORegistryEntrySearchCFProperty(
+        service, kIODeviceTreePlane, "entangle-nonce" as NSString, kCFAllocatorDefault, UInt32(kIORegistryIterateRecursively)
+    ) else {
         return false
     }
-
-    IOObjectRelease(service)
+    
     return true
 }
 

--- a/main.swift
+++ b/main.swift
@@ -96,7 +96,7 @@ request(body: parameters) { success, data in
                 exit(1)
             }
             print("Link to blobs: \(link)")
-            if CommandLine.arguments.contains("--copy") || CommandLine.arguments.contains("-c") {
+            if CommandLine.arguments.contains("--copy-link") || CommandLine.arguments.contains("-c") {
                 UIPasteboard.general.string = link
                 print("Copied link to clipboard.")
             }


### PR DESCRIPTION
This pull request adds the --copy-link / -c option which copies the returned link by TSS Saver to clipboard, and also makes some other general code enhancements